### PR TITLE
Compress initrd output

### DIFF
--- a/abootimg-pack-initrd
+++ b/abootimg-pack-initrd
@@ -19,5 +19,5 @@ if [ -f $initrd -a -z "$forcewrite" ]; then
     exit 1
 fi
 
-( cd $ramdisk; find | sort | cpio --quiet -o -H newc --owner=root:root ) | gzip > $initrd
+( cd $ramdisk; find | sort | cpio --quiet -o -H newc --owner=root:root ) | gzip -9 > $initrd
 


### PR DESCRIPTION
This patch compresses the initrd output by abootimg-pack-initrd.
